### PR TITLE
Hotfix: always use int for encoding

### DIFF
--- a/bdranalytics/pipeline/encoders.py
+++ b/bdranalytics/pipeline/encoders.py
@@ -133,7 +133,7 @@ class StringIndexer(BaseEstimator, TransformerMixin):
         for col in self.columns:
             dictionary = self.dictionaries[col]
             na_value = len(dictionary) + 1
-            transformed_column = X[col].apply(lambda x: dictionary.get(x, na_value))
+            transformed_column = X[col].apply(lambda x: dictionary.get(x, na_value)).astype(int)
             column_array.append(transformed_column.values.reshape(-1, 1))
         return np.hstack(column_array)
 


### PR DESCRIPTION
Pandas categorical columns remain categoricals after encoding. Explicit conversion to integer is necessary.